### PR TITLE
fix: Correct source path for desktop-file in snapcraft.yaml

### DIFF
--- a/snap/snapcraft.yaml
+++ b/snap/snapcraft.yaml
@@ -42,7 +42,7 @@ parts:
   # Part for the desktop file
   desktop-file:
     plugin: dump
-    source: snap/gui # Directory containing lxd-indicator.desktop
+    source: .. # Source is the parent directory (project root)
     organize:
       'lxd-indicator.desktop': meta/gui/lxd-indicator.desktop
 


### PR DESCRIPTION
The 'desktop-file' part in snapcraft.yaml was failing because the 'source: snap/gui' path did not exist. The lxd-indicator.desktop file is located in the project root.

This commit changes the source to '..' (relative to snapcraft.yaml, pointing to the project root) to correctly locate the desktop file. The 'organize' key remains the same to ensure the file is placed correctly within the snap.