### PR TITLE
fix(snap): Correct packaging for GTK app

### DIFF
--- a/snap/snapcraft.yaml
+++ b/snap/snapcraft.yaml
@@ -11,13 +11,20 @@ confinement: strict
 apps:
   lxd-indicator:
     command: bin/lxd-indicator.py
+    command-chain: [snap/command-chain/desktop-launch]
     extensions:
       - gnome # Use 'gnome' for core22, not 'gnome-3-38'
     plugs:
       - network
       - gsettings
       - lxd
+      - desktop
+      - opengl
+      - wayland
+      - x11
     autostart: lxd-indicator.desktop
+    environment:
+      GTK_USE_PORTAL: '1'
 
 parts:
   lxd-indicator:


### PR DESCRIPTION
The lxd-indicator snap was experiencing a segmentation fault on startup. This is a common issue for graphical applications in snaps when they are not configured with the correct permissions and environment to interact with the host's desktop system.

This commit fixes the issue by updating the `snapcraft.yaml` to:
- Add a `command-chain` that uses the `desktop-launch` script provided by the `gnome` extension. This script sets up the necessary environment variables for a GTK application.
- Add the required plugs for a desktop application: `desktop`, `opengl`, `wayland`, and `x11`. These give the application access to the desktop environment and display server.
- Set the `GTK_USE_PORTAL=1` environment variable, which is the recommended way for sandboxed GTK applications to integrate with the desktop (e.g., for file dialogs).