### PR TITLE
I've fixed a segmentation fault on startup and improved your applicat…

### DIFF
--- a/lxd-indicator.py
+++ b/lxd-indicator.py
@@ -118,20 +118,20 @@ class LXDIndicatorApp:
             self.lxd_client = None
             self.lxd_error_message = f"LXD API Attribute Error during fetch: {e}. Re-initializing connection."
             print(f"Error during fetch: {self.lxd_error_message}")
-            return
+            return []
         except ClientConnectionFailed:
             self.lxd_client = None
             self.lxd_error_message = "LXD Connection Lost: Daemon unreachable."
             print(f"Error during fetch: {self.lxd_error_message}")
-            return
+            return []
         except LXDAPIException as e:
             self.lxd_error_message = f"LXD API Error during fetch: {e}"
             print(f"Error during fetch: {self.lxd_error_message}")
-            return
+            return []
         except Exception as e:
             self.lxd_error_message = f"Unexpected error fetching instances: {e}"
             print(f"Error during fetch: {self.lxd_error_message}")
-            return
+            return []
 
 
     def _periodic_refresh_lxd_data(self):

--- a/snap/snapcraft.yaml
+++ b/snap/snapcraft.yaml
@@ -45,4 +45,6 @@ parts:
       cp $SNAPCRAFT_PROJECT_DIR/lxd-indicator.py $SNAPCRAFT_PART_INSTALL/bin/lxd-indicator.py
       # Ensure the script is executable
       chmod +x $SNAPCRAFT_PART_INSTALL/bin/lxd-indicator.py
+      # Also copy the icon, to be sure it's located where the script expects it.
+      cp $SNAPCRAFT_PROJECT_DIR/lxd_logo.png $SNAPCRAFT_PART_INSTALL/
       cp $SNAPCRAFT_PROJECT_DIR/lxd-indicator.desktop $SNAPCRAFT_PART_INSTALL/lxd-indicator.desktop


### PR DESCRIPTION
…ion's error handling.

Your application was crashing with a segmentation fault when started from the snap package because the application icon, `lxd_logo.png`, was not included. This caused the `AppIndicator3.Indicator.new()` function call to fail.

I fixed this by modifying `snap/snapcraft.yaml` to copy the icon into the snap during the build process, ensuring it's available at the expected path.

I also improved the error handling in the `_fetch_lxd_instances_with_error_handling` function in `lxd-indicator.py`. The function will now always return a list, even in error cases, making the application more robust.