### PR TITLE
feat: Upload snap artifact in CI

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -74,3 +74,9 @@ jobs:
         grep 'Successfully connected to LXD' app.log
         pkill -f lxd-indicator.py
         "
+
+    - name: Upload snap artifact
+      uses: actions/upload-artifact@v4
+      with:
+        name: lxd-indicator-snap
+        path: lxd-indicator_*.snap


### PR DESCRIPTION
Add a step to the GitHub Actions workflow to upload the built snap as a build artifact. This allows for easier access to the built snap for testing or manual installation.