### PR TITLE
fix(snap): Correct GDK Pixbuf loader cache generation

### DIFF
--- a/snap/command-chain/desktop-launch.sh
+++ b/snap/command-chain/desktop-launch.sh
@@ -12,12 +12,19 @@ export GTK_THEME="Adwaita:dark"
 # Create a writable cache file and export the environment variable
 GDK_PIXBUF_CACHE_FILE="$SNAP_USER_DATA/.cache/gdk-pixbuf-loaders.cache"
 mkdir -p "$(dirname "$GDK_PIXBUF_CACHE_FILE")"
+
 # Find the query tool and execute it
 GDK_PIXBUF_QUERY_LOADERS_EXEC=$(find "$SNAP" -name gdk-pixbuf-query-loaders | head -n 1)
 if [ -n "$GDK_PIXBUF_QUERY_LOADERS_EXEC" ]; then
   echo "Updating GDK pixbuf loaders cache..."
-  "$GDK_PIXBUF_QUERY_LOADERS_EXEC" > "$GDK_PIXBUF_CACHE_FILE"
-  export GDK_PIXBUF_MODULE_FILE="$GDK_PIXBUF_CACHE_FILE"
+  # Find all loader modules and pass them to the query tool
+  LOADER_MODULES=$(find "$SNAP/usr/lib" -name 'libpixbufloader-*.so')
+  if [ -n "$LOADER_MODULES" ]; then
+    "$GDK_PIXBUF_QUERY_LOADERS_EXEC" $LOADER_MODULES > "$GDK_PIXBUF_CACHE_FILE"
+    export GDK_PIXBUF_MODULE_FILE="$GDK_PIXBUF_CACHE_FILE"
+  else
+    echo "WARNING: No GDK pixbuf loaders found."
+  fi
 else
   echo "WARNING: gdk-pixbuf-query-loaders not found."
 fi


### PR DESCRIPTION
The application was failing on startup with a Gtk-ERROR related to unrecognized image file formats. This was caused by the GDK Pixbuf loader cache not being correctly generated within the snap environment.

The `desktop-launch.sh` script was calling `gdk-pixbuf-query-loaders` without specifying where to find the loader modules. This resulted in an invalid cache file.

This commit fixes the issue by modifying `desktop-launch.sh` to find all `libpixbufloader-*.so` modules within the snap and pass them explicitly to `gdk-pixbuf-query-loaders`. This ensures the generated cache contains the correct paths, allowing GTK to load icons successfully.