### PR TITLE
fix(ci): Fix DBus error in CI by mocking systemd service

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -78,7 +78,7 @@ jobs:
         echo 'Exec=/bin/true' >> \$SERVICE_FILE
 
         xvfb-run dbus-run-session lxd-indicator > app.log 2>&1 &
-        sleep 10
+        sleep 30
         echo '--- Application logs ---'
         cat app.log
         echo '------------------------'

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -66,6 +66,18 @@ jobs:
         set -ex
         export GDK_BACKEND=x11
         mkdir -p /home/runner/snap/lxd-indicator/common/.cache
+
+        # Create a fake systemd service to satisfy AppIndicator3.
+        # The indicator library tries to activate this service on startup,
+        # and fails if it's not present. We can create a dummy service
+        # that does nothing but successfully activates.
+        mkdir -p /home/runner/.local/share/dbus-1/services
+        cat > /home/runner/.local/share/dbus-1/services/org.freedesktop.systemd1.service <<EOF
+[D-BUS Service]
+Name=org.freedesktop.systemd1
+Exec=/bin/true
+EOF
+
         xvfb-run dbus-run-session lxd-indicator > app.log 2>&1 &
         sleep 10
         echo '--- Application logs ---'

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -72,11 +72,10 @@ jobs:
         # and fails if it's not present. We can create a dummy service
         # that does nothing but successfully activates.
         mkdir -p /home/runner/.local/share/dbus-1/services
-        cat > /home/runner/.local/share/dbus-1/services/org.freedesktop.systemd1.service <<EOF
-[D-BUS Service]
-Name=org.freedesktop.systemd1
-Exec=/bin/true
-EOF
+        SERVICE_FILE=/home/runner/.local/share/dbus-1/services/org.freedesktop.systemd1.service
+        echo '[D-BUS Service]' > \$SERVICE_FILE
+        echo 'Name=org.freedesktop.systemd1' >> \$SERVICE_FILE
+        echo 'Exec=/bin/true' >> \$SERVICE_FILE
 
         xvfb-run dbus-run-session lxd-indicator > app.log 2>&1 &
         sleep 10


### PR DESCRIPTION
The lxd-indicator application uses the AppIndicator3 library, which attempts to activate the `org.freedesktop.systemd1` DBus service on startup. In the minimal CI environment, this service is not available, causing the application to fail before tests can run.

This change adds a workaround to the CI test setup to create a fake `org.freedesktop.systemd1` DBus service. This mock service simply executes `/bin/true`, which is enough to satisfy the AppIndicator3 library and allow the application to start up correctly.