### PR TITLE
feat: Update to core24 and ubuntu-24.04

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -8,7 +8,7 @@ on:
 
 jobs:
   build-and-test-snap:
-    runs-on: ubuntu-22.04
+    runs-on: ubuntu-24.04
     steps:
     - name: Checkout code
       uses: actions/checkout@v4
@@ -31,7 +31,7 @@ jobs:
 
     - name: Pre-install build dependencies with retries
       run: |
-        for snap in gtk-common-themes gnome-42-2204-sdk gnome-42-2204; do
+        for snap in gtk-common-themes gnome-46-2404-sdk gnome-46-2404; do
           echo "--- Installing $snap ---"
           for i in 1 2 3; do
             if sudo snap install "$snap"; then

--- a/snap/snapcraft.yaml
+++ b/snap/snapcraft.yaml
@@ -1,5 +1,5 @@
 name: lxd-indicator
-base: core22
+base: core24
 version: '0.1'
 summary: LXD instance status indicator
 description: |
@@ -36,11 +36,11 @@ parts:
       - python3-gi
       - gir1.2-gtk-3.0
       - gir1.2-appindicator3-0.1
-      - libappindicator3-1
+      - libayatana-appindicator3-1
       - libgirepository-1.0-1
       - gir1.2-gdkpixbuf-2.0
       - dconf-gsettings-backend
-      - libgdk-pixbuf-2.0-0
+      - libgdk-pixbuf2.0-0
       - libgtk-3-bin
       - libglib2.0-0
       - librsvg2-common


### PR DESCRIPTION
Updates the snap to use 'core24' as its base and the CI workflow to run on 'ubuntu-24.04'.

Also updates the `stage-packages` in `snapcraft.yaml` to be compatible with Ubuntu 24.04:
- Renamed `libappindicator3-1` to `libayatana-appindicator3-1`.
- Renamed `libgdk-pixbuf-2.0-0` to `libgdk-pixbuf2.0-0`.